### PR TITLE
Fix crash for empty anilist ids

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,3 +1,4 @@
 .next/
 out/
 public/js/js.js
+.github/

--- a/pages/index.js
+++ b/pages/index.js
@@ -295,7 +295,7 @@ const Index = () => {
 
     const topSearchResults = topResults.map((entry) => {
       const id = entry.anilist ?? 0;
-      const entryMetadata = metadata.find(entry => entry.id === id);
+      const entryMetadata = metadata.find((entry) => entry.id === id);
 
       if (entryMetadata) {
         entry.anilist = entryMetadata;


### PR DESCRIPTION
Optimized by only querying valid anilist ids.
When the API returns no anilist id it is ignored and uses the file name instead.

When the API response returns 0 as frame count it is not displayed.

![Screenshot from 2024-09-03 21-39-54](https://github.com/user-attachments/assets/1995f98e-3c49-4e0b-9793-4774dc69d688)
