### PR TITLE
Add persistent login with header user menu and dedicated login page

### DIFF
--- a/components/account.module.css
+++ b/components/account.module.css
@@ -133,6 +133,29 @@
   background-color: var(--shadow-color);
   border-color: var(--shadow-color);
 }
+.loginPrompt {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  padding: 0.3rem 0.5rem;
+}
+.loginLink {
+  display: inline-block;
+  padding: 0 0.5rem;
+  line-height: 1.5rem;
+  font-size: 0.8rem;
+  color: var(--blank-color);
+  background: var(--theme-main-color);
+  border: 1px solid var(--theme-weak-color);
+  border-radius: 3px;
+}
+.loginLink:hover {
+  color: var(--blank-color);
+  text-decoration: none;
+  box-shadow: 0 0 10px var(--theme-weak-color);
+}
 .meterBG {
   fill: var(--shadow-color);
 }

--- a/components/auth.tsx
+++ b/components/auth.tsx
@@ -1,0 +1,114 @@
+import { createContext, useContext, useEffect, useState } from "react";
+
+const NEXT_PUBLIC_API_ENDPOINT = process.env.NEXT_PUBLIC_API_ENDPOINT;
+const STORAGE_KEY = "trace.moe-api-key";
+
+export const isGuest = (id) => (id.indexOf("@") >= 0 ? false : true);
+export const isAdmin = (id) => (id.match(/^[a-zA-Z0-9_.+-]+@trace.moe$/) ? true : false);
+export const initials = (email: string) =>
+  email
+    .split("@")[0]
+    .split(/[._+-]/)
+    .filter(Boolean)
+    .slice(0, 2)
+    .map((e) => e[0].toUpperCase())
+    .join("");
+export const getStoredApiKey = () =>
+  typeof localStorage === "undefined" ? "" : localStorage.getItem(STORAGE_KEY) || "";
+
+interface User {
+  id: string;
+  priority: number;
+  concurrency: number;
+  quota: number;
+  quotaUsed: number;
+}
+
+interface AuthContextValue {
+  status: "loading" | "guest" | "user";
+  user: User | null;
+  apiKey: string;
+  login: (email: string, password: string) => Promise<{ ok: boolean; error?: string }>;
+  logout: () => Promise<void>;
+  setApiKey: (key: string) => void;
+  refresh: () => Promise<void>;
+}
+
+const AuthContext = createContext<AuthContextValue>(null);
+export const useAuth = () => useContext(AuthContext);
+
+export function AuthProvider({ children }) {
+  const [status, setStatus] = useState<"loading" | "guest" | "user">("loading");
+  const [user, setUser] = useState<User | null>(null);
+  const [apiKey, setApiKeyState] = useState("");
+
+  const fetchMe = async (key: string) => {
+    try {
+      const res = await fetch(`${NEXT_PUBLIC_API_ENDPOINT}/me`, {
+        headers: { "x-trace-key": key || "" },
+      });
+      if (res.status >= 400) return null;
+      return await res.json();
+    } catch (e) {
+      return null;
+    }
+  };
+
+  const applySession = async (key: string) => {
+    let me = await fetchMe(key);
+    if (!me && key) {
+      // stored key is no longer valid, fall back to guest
+      localStorage.removeItem(STORAGE_KEY);
+      key = "";
+      me = await fetchMe("");
+    }
+    setUser(me);
+    setApiKeyState(me ? key : "");
+    setStatus(me && key && !isGuest(me.id) ? "user" : "guest");
+  };
+
+  useEffect(() => {
+    applySession(getStoredApiKey());
+    const syncTabs = (e: StorageEvent) => {
+      if (e.key === STORAGE_KEY) applySession(e.newValue || "");
+    };
+    window.addEventListener("storage", syncTabs);
+    return () => window.removeEventListener("storage", syncTabs);
+  }, []);
+
+  const login = async (email: string, password: string) => {
+    const res = await fetch(`${NEXT_PUBLIC_API_ENDPOINT}/user/login`, {
+      method: "POST",
+      body: JSON.stringify({ email, password }),
+      headers: { "Content-Type": "application/json" },
+    });
+    if (res.status >= 400) {
+      return { ok: false, error: (await res.json()).error };
+    }
+    const key = (await res.json()).key;
+    localStorage.setItem(STORAGE_KEY, key);
+    await applySession(key);
+    return { ok: true };
+  };
+
+  const logout = async () => {
+    localStorage.removeItem(STORAGE_KEY);
+    await applySession("");
+  };
+
+  const setApiKey = (key: string) => {
+    localStorage.setItem(STORAGE_KEY, key);
+    setApiKeyState(key);
+  };
+
+  const refresh = async () => {
+    const me = await fetchMe(apiKey);
+    if (me) setUser(me);
+  };
+
+  return (
+    <AuthContext.Provider value={{ status, user, apiKey, login, logout, setApiKey, refresh }}>
+      {children}
+    </AuthContext.Provider>
+  );
+}

--- a/components/layout.tsx
+++ b/components/layout.tsx
@@ -2,6 +2,8 @@ import Head from "next/head";
 import Link from "next/link";
 import { useEffect, useState } from "react";
 
+import UserMenu from "./user-menu";
+
 import styles from "./footer.module.css";
 import sponsorStyles from "./sponsor.module.css";
 
@@ -33,6 +35,7 @@ export default function Layout({ children, title }) {
         <link rel="apple-touch-icon" href="/favicon144.png" />
         <link rel="manifest" href="/manifest.json" />
       </Head>
+      <UserMenu></UserMenu>
       <main className={styles.main}>{children}</main>
 
       <div

--- a/components/search-bar.module.css
+++ b/components/search-bar.module.css
@@ -231,3 +231,10 @@
     justify-content: center;
   }
 }
+
+/* keep the search controls clear of the corner user menu */
+@media (max-width: 1100px) {
+  .searchBarReady .formControls {
+    margin-right: 2.75rem;
+  }
+}

--- a/components/user-menu.module.css
+++ b/components/user-menu.module.css
@@ -1,0 +1,87 @@
+.userMenu {
+  position: absolute;
+  top: 0.5rem;
+  right: calc(0.75rem + env(safe-area-inset-right));
+  z-index: 110;
+}
+.loginBtn {
+  display: inline-block;
+  line-height: 2rem;
+  padding: 0 1rem;
+  font-size: 0.8rem;
+  color: var(--blank-color);
+  background: var(--theme-main-color);
+  border-radius: 3px;
+  box-shadow: 1px 1px 3px var(--shadow-color);
+  transition: box-shadow 100ms ease-out;
+}
+.loginBtn:hover {
+  color: var(--blank-color);
+  text-decoration: none;
+  box-shadow: 1px 1px 3px var(--theme-weak-color);
+}
+.avatar {
+  width: 2rem;
+  height: 2rem;
+  border-radius: 50%;
+  border: 0;
+  padding: 0;
+  color: var(--blank-color);
+  background: var(--theme-main-color);
+  font-size: 0.8rem;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  outline: 0;
+  box-shadow: 1px 1px 3px var(--shadow-color);
+  transition: box-shadow 100ms ease-out;
+}
+.avatar:hover,
+.avatar:focus {
+  box-shadow: 0 0 10px var(--theme-weak-color);
+}
+.dropdown {
+  position: absolute;
+  top: calc(100% + 0.4rem);
+  right: 0;
+  min-width: 11rem;
+  max-width: calc(100vw - 1.5rem);
+  padding: 0.25rem 0;
+  background: var(--blank-color);
+  box-shadow: 0 0 20px var(--shadow-color);
+  border-radius: 0.5rem;
+  font-size: 0.8rem;
+}
+.dropdownEmail {
+  padding: 0.5rem 1rem;
+  color: var(--text-weak-color);
+  font-size: 0.75rem;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.dropdownItem {
+  display: block;
+  width: 100%;
+  box-sizing: border-box;
+  text-align: left;
+  padding: 0.6rem 1rem;
+  color: var(--text-main-color);
+  background: transparent;
+  border: 0;
+  font-size: 0.8rem;
+  line-height: 1rem;
+  cursor: pointer;
+  outline: 0;
+}
+.dropdownItem:hover,
+.dropdownItem:focus {
+  background: var(--shadow-color);
+  color: var(--text-strong-color);
+  text-decoration: none;
+}
+.separator {
+  border-top: 1px dashed var(--theme-weak-color);
+  margin: 0.25rem 0;
+}

--- a/components/user-menu.tsx
+++ b/components/user-menu.tsx
@@ -1,0 +1,86 @@
+import Link from "next/link";
+import { useRouter } from "next/router";
+import { useEffect, useRef, useState } from "react";
+
+import { initials, useAuth } from "./auth";
+
+import styles from "./user-menu.module.css";
+
+export default function UserMenu() {
+  const { status, user, logout } = useAuth();
+  const [open, setOpen] = useState(false);
+  const containerRef = useRef<HTMLDivElement>(null);
+  const avatarRef = useRef<HTMLButtonElement>(null);
+  const router = useRouter();
+
+  useEffect(() => {
+    if (!open) return;
+    const onPointerDown = (e: PointerEvent) => {
+      if (!containerRef.current?.contains(e.target as Node)) setOpen(false);
+    };
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        setOpen(false);
+        avatarRef.current?.focus();
+      }
+    };
+    document.addEventListener("pointerdown", onPointerDown);
+    document.addEventListener("keydown", onKeyDown);
+    return () => {
+      document.removeEventListener("pointerdown", onPointerDown);
+      document.removeEventListener("keydown", onKeyDown);
+    };
+  }, [open]);
+
+  if (status === "loading") return <div className={styles.userMenu}></div>;
+
+  if (status === "guest") {
+    if (router.pathname === "/login") return null;
+    return (
+      <div className={styles.userMenu}>
+        <Link className={styles.loginBtn} href={`/login?next=${encodeURIComponent(router.asPath)}`}>
+          Login
+        </Link>
+      </div>
+    );
+  }
+
+  return (
+    <div className={styles.userMenu} ref={containerRef}>
+      <button
+        className={styles.avatar}
+        ref={avatarRef}
+        aria-haspopup="menu"
+        aria-expanded={open}
+        aria-label="Account menu"
+        onClick={() => setOpen(!open)}
+      >
+        {initials(user.id)}
+      </button>
+      {open && (
+        <div className={styles.dropdown} role="menu">
+          <div className={styles.dropdownEmail}>{user.id}</div>
+          <Link
+            className={styles.dropdownItem}
+            role="menuitem"
+            href="/account"
+            onClick={() => setOpen(false)}
+          >
+            Account
+          </Link>
+          <div className={styles.separator}></div>
+          <button
+            className={styles.dropdownItem}
+            role="menuitem"
+            onClick={() => {
+              setOpen(false);
+              logout();
+            }}
+          >
+            Logout
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,6 +1,11 @@
 import "../styles/normalize.css";
 import "../styles/global.css";
+import { AuthProvider } from "../components/auth";
 
 export default function App({ Component, pageProps }) {
-  return <Component {...pageProps} />;
+  return (
+    <AuthProvider>
+      <Component {...pageProps} />
+    </AuthProvider>
+  );
 }

--- a/pages/account.tsx
+++ b/pages/account.tsx
@@ -1,5 +1,7 @@
+import Link from "next/link";
 import { useEffect, useState } from "react";
 
+import { isAdmin, isGuest, useAuth } from "../components/auth";
 import Layout from "../components/layout";
 
 import accountStyles from "../components/account.module.css";
@@ -7,79 +9,31 @@ import styles from "../components/layout.module.css";
 
 const NEXT_PUBLIC_API_ENDPOINT = process.env.NEXT_PUBLIC_API_ENDPOINT;
 
-const isGuest = (id) => (id.indexOf("@") >= 0 ? false : true);
-const isAdmin = (id) => (id.match(/^[a-zA-Z0-9_.+-]+@trace.moe$/) ? true : false);
-
 const Account = () => {
-  const [apiKey, setAPIKey] = useState("");
   const [apiKeyLabel, setAPIKeyLabel] = useState("");
   const [isResettingApiKey, setIsResettingApiKey] = useState(false);
   const [createUserLabel, setCreateUserLabel] = useState("");
   const [isCreatingUser, setIsCreatingUser] = useState(false);
-  const [loading, setLoading] = useState(true);
   const [confirmed, setConfirmed] = useState(undefined);
   const [dialogue, setDialogue] = useState("");
-  const [user, setUser] = useState({
+  const { status, user: authUser, apiKey, setApiKey, refresh, logout } = useAuth();
+  const loading = status === "loading";
+  const user = authUser || {
     concurrency: 0,
     id: "",
     priority: 0,
     quota: 0,
     quotaUsed: 0,
-  });
-  const login = async (apiKey?: string) => {
-    setLoading(true);
-    let res = await fetch(`${NEXT_PUBLIC_API_ENDPOINT}/me`, {
-      headers: { "x-trace-key": apiKey || "" },
-    });
-    setAPIKey(res.status >= 400 ? "" : apiKey);
-    const user = await res.json();
-    setUser(user);
-    setLoading(false);
-    setAPIKeyLabel("");
-    setCreateUserLabel("");
   };
 
   useEffect(() => {
-    login();
-  }, []);
+    if (!loading) refresh();
+  }, [status]);
 
-  const submitLogin = async (e) => {
+  const submitLogout = async (e) => {
     e.preventDefault();
-    e.target.querySelectorAll("input").forEach((e) => {
-      e.disabled = true;
-    });
-    e.target.querySelector("#login-label").classList.remove(accountStyles.error);
-    e.target.querySelector("#login-label").innerText = "";
-    const email = e.target.querySelector("input[type=email]").value;
-    const password = e.target.querySelector("input[type=password]").value;
-    e.target.querySelector("#login-label").innerText = "Logging in...";
-    const res = await fetch(`${NEXT_PUBLIC_API_ENDPOINT}/user/login`, {
-      method: "POST",
-      body: JSON.stringify({
-        email,
-        password,
-      }),
-      headers: { "Content-Type": "application/json" },
-    });
-    if (res.status >= 400) {
-      e.target.querySelector("#login-label").innerText = (await res.json()).error;
-      e.target.querySelector("#login-label").classList.add(accountStyles.error);
-    } else {
-      await login((await res.json()).key);
-      e.target.querySelector("#login-label").innerText = "";
-    }
-
-    e.target.querySelectorAll("input").forEach((e) => {
-      e.disabled = false;
-    });
-  };
-  const logout = async (e) => {
-    e.preventDefault();
-    e.target.disabled = true;
     e.target.querySelector("#logout-label").innerText = "Logging out...";
-    await login();
-    e.target.querySelector("#logout-label").innerText = "";
-    e.target.disabled = false;
+    await logout();
   };
 
   const submitPassword = async (e) => {
@@ -127,7 +81,7 @@ const Account = () => {
         } else {
           const newApiKey = (await res.json()).key;
           setAPIKeyLabel("API Key has been reset.");
-          setAPIKey(newApiKey);
+          setApiKey(newApiKey);
         }
       }
       setConfirmed(undefined);
@@ -278,43 +232,12 @@ const Account = () => {
           <div className={`${accountStyles.box}`}>
             <div className={accountStyles.boxTitle}>Login</div>
             <div className={accountStyles.boxBody}>
-              <form onSubmit={submitLogin}>
-                <table>
-                  <tbody>
-                    <tr>
-                      <td>
-                        <label>User ID: </label>
-                      </td>
-                      <td>
-                        <div>
-                          <input type="email" size={1} placeholder="email address" required />
-                        </div>
-                      </td>
-                    </tr>
-                    <tr>
-                      <td>
-                        <label>Password: </label>
-                      </td>
-                      <td>
-                        <div>
-                          <input
-                            type="password"
-                            size={1}
-                            placeholder="password"
-                            minLength={8}
-                            autoComplete="current-password"
-                            required
-                          />
-                        </div>
-                      </td>
-                    </tr>
-                  </tbody>
-                </table>
-                <div>
-                  <div id="login-label"></div>
-                  <input type="submit" value="Login" />
-                </div>
-              </form>
+              <div className={accountStyles.loginPrompt}>
+                <div>Log in to view your account quota and API key.</div>
+                <Link className={accountStyles.loginLink} href="/login?next=/account">
+                  Login
+                </Link>
+              </div>
             </div>
           </div>
         )}
@@ -323,7 +246,7 @@ const Account = () => {
           <div className={`${accountStyles.box} logout`}>
             <div className={accountStyles.boxTitle}>Logout</div>
             <div className={accountStyles.boxBody}>
-              <form onSubmit={logout}>
+              <form onSubmit={submitLogout}>
                 <div>
                   <div id="logout-label"></div>
                   <input type="submit" value="Logout" />

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,6 +1,8 @@
 import Head from "next/head";
-import { useEffect, useState } from "react";
+import Link from "next/link";
+import { ReactNode, useEffect, useState } from "react";
 
+import { getStoredApiKey, useAuth } from "../components/auth";
 import Info from "../components/info";
 import Layout from "../components/layout";
 import Player from "../components/player";
@@ -15,7 +17,7 @@ const Index = () => {
   const [dropTargetText, setDropTargetText] = useState("");
   const [isCutBorders, setIsCutBorders] = useState(true);
   const [anilistFilter, setAnilistFilter] = useState();
-  const [messageText, setMessageText] = useState("");
+  const [messageText, setMessageText] = useState<ReactNode>("");
   const [imageURL, setImageURL] = useState(undefined);
   const [searchImage, setSearchImage] = useState<string | Blob>("");
   const [searchImageSrc, setSearchImageSrc] = useState("");
@@ -29,6 +31,7 @@ const Index = () => {
   const [playerFileName, setPlayerFileName] = useState("");
   const [isLoading, setIsLoading] = useState(false);
   const [isSearching, setIsSearching] = useState(false);
+  const { status, apiKey } = useAuth();
 
   useEffect(() => {
     const searchParams = new URLSearchParams(location.search);
@@ -153,11 +156,14 @@ const Index = () => {
       isCutBorders ? "cutBorders" : "",
       anilistFilter ? `anilistID=${anilistFilter}` : "",
     ].join("&");
+    // fall back to the stored key in case a search fires before /me resolves on load
+    const searchApiKey = apiKey || getStoredApiKey();
     let res;
     for (let retries = 5; retries > 0; retries--) {
       res = await fetch(`${NEXT_PUBLIC_API_ENDPOINT}/search?${queryString}`, {
         method: "POST",
         body: formData,
+        headers: searchApiKey ? { "x-trace-key": searchApiKey } : {},
       });
       if (res.status !== 503 || retries === 1) {
         break;
@@ -175,6 +181,19 @@ const Index = () => {
     }
     if (res.status === 503) {
       setMessageText("Server is busy, please try again later.");
+      return;
+    }
+    if (res.status === 402) {
+      setMessageText(
+        status === "user" ? (
+          "Search quota depleted, please try again tomorrow."
+        ) : (
+          <>
+            Search quota for your IP is depleted. <Link href="/login?next=/">Log in</Link> to use
+            your account quota.
+          </>
+        ),
+      );
       return;
     }
     if (res.status >= 400) {

--- a/pages/login.tsx
+++ b/pages/login.tsx
@@ -1,0 +1,108 @@
+import { useRouter } from "next/router";
+import { useEffect, useState } from "react";
+
+import { useAuth } from "../components/auth";
+import Layout from "../components/layout";
+
+import accountStyles from "../components/account.module.css";
+import styles from "../components/layout.module.css";
+
+const getRedirectTarget = (next) =>
+  typeof next === "string" && next.startsWith("/") && !next.startsWith("//") ? next : "/";
+
+const Login = () => {
+  const { status, login } = useAuth();
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [label, setLabel] = useState("");
+  const [isError, setIsError] = useState(false);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const router = useRouter();
+
+  useEffect(() => {
+    if (status === "user" && router.isReady) {
+      router.replace(getRedirectTarget(router.query.next));
+    }
+  }, [status, router.isReady]);
+
+  const submitLogin = async (e) => {
+    e.preventDefault();
+    setIsSubmitting(true);
+    setIsError(false);
+    setLabel("Logging in...");
+    const result = await login(email, password);
+    if (result.ok) {
+      setLabel("");
+    } else {
+      setLabel(result.error);
+      setIsError(true);
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <Layout title="Login">
+      <div className={`${styles.container} ${styles.page}`}>
+        <div className={styles.pageHeader}>Login</div>
+
+        <div className={accountStyles.box}>
+          <div className={accountStyles.boxTitle}>Login</div>
+          <div className={accountStyles.boxBody}>
+            <form onSubmit={submitLogin}>
+              <table>
+                <tbody>
+                  <tr>
+                    <td>
+                      <label>User ID: </label>
+                    </td>
+                    <td>
+                      <div>
+                        <input
+                          type="email"
+                          name="email"
+                          size={1}
+                          placeholder="email address"
+                          autoComplete="email"
+                          required
+                          value={email}
+                          disabled={isSubmitting}
+                          onChange={(e) => setEmail(e.target.value)}
+                        />
+                      </div>
+                    </td>
+                  </tr>
+                  <tr>
+                    <td>
+                      <label>Password: </label>
+                    </td>
+                    <td>
+                      <div>
+                        <input
+                          type="password"
+                          name="password"
+                          size={1}
+                          placeholder="password"
+                          minLength={8}
+                          autoComplete="current-password"
+                          required
+                          value={password}
+                          disabled={isSubmitting}
+                          onChange={(e) => setPassword(e.target.value)}
+                        />
+                      </div>
+                    </td>
+                  </tr>
+                </tbody>
+              </table>
+              <div>
+                <div className={isError ? accountStyles.error : ""}>{label}</div>
+                <input type="submit" value="Login" disabled={isSubmitting} />
+              </div>
+            </form>
+          </div>
+        </div>
+      </div>
+    </Layout>
+  );
+};
+export default Login;


### PR DESCRIPTION
### Why

The Login state only worked on the account page, so a refresh forgot the logged-in user. The API key was never sent on searches so when a free-tier visitor hit the IP quota, logging in didn't help them keep searching on the website itself.

### What

- Persist the API key in localStorage via a shared AuthProvider so login survives refreshes, with cross-tab sync and invalid-key fallback
- Move the login form from the account page to a dedicated /login page with ?next= redirect back to the originating page
- Add a top-right Login button / initials-avatar dropdown (Account, Logout) on all pages, with keyboard/outside-click handling and mobile clearance in the results search bar
- Show a login CTA on the account page for guests
- Send x-trace-key on /search when logged in and show a login prompt when the 402 quota-depleted response is returned